### PR TITLE
お散歩履歴詳細画面で歩数が 「xx歩歩」と表示される不具合の修正

### DIFF
--- a/app/src/main/java/jp/co/azz/maps/DetailActivity.java
+++ b/app/src/main/java/jp/co/azz/maps/DetailActivity.java
@@ -163,7 +163,7 @@ public class DetailActivity extends AppCompatActivity
         distance.setText(history.getKilometer());
         
         TextView step_cnt = this.findViewById(R.id.main_step);
-        step_cnt.setText(String.valueOf(history.getNumberOfSteps()+ "歩"));
+        step_cnt.setText(String.valueOf(history.getNumberOfSteps()));
 
         TextView calorie = this.findViewById(R.id.main_calorie);
         calorie.setText(String.valueOf(history.getCalorie()));


### PR DESCRIPTION
お散歩履歴詳細画面で、歩数が`xx歩歩` と表示される。不具合の修正

@azzrhoshino @ykyk3  @azzrtaguchi @watahiki606 
レビューをお願いします。